### PR TITLE
change user from subject to behavior subject

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Subject, catchError, tap, throwError } from 'rxjs';
+import { BehaviorSubject, catchError, tap, throwError } from 'rxjs';
 import { User } from '../shared/user.model';
-import { LocalizedString } from '@angular/compiler';
+
 
 interface AuthResponseData {
   // kind: string;
@@ -23,7 +23,7 @@ interface LoginResponseData {
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  user = new Subject<User>();
+  user = new BehaviorSubject<User>(null);
 
   constructor(private http: HttpClient) {}
   apiKey = 'AIzaSyDIVVW0j9RT0xUJoZJkHtJlYq2nyjF7gp4';


### PR DESCRIPTION
Subject will subscribe to all future emits of the subject but behavior will do that also but will also get the last emit. this is important in our data service and other places so that it can see if the user is actively authenticated because maybe that info, especially token info, would have been emitted at that time. now with behaviorsubject it will be.